### PR TITLE
Complete deletion of old branch 25-clean-up-parser-grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ package-lock.json
 .eslistrc.json
 name-ext/node_modules
 name-ext/node_modules/*
+
+# These should now be obsolete
 tmp/
 tmp/*
 
@@ -28,6 +30,6 @@ tmp/*
 *.asm
 *.out
 *.o
-!name-as/.artifacts/*
+name-as/.artifacts/*
 name-fmt/node_modules/
 *.li

--- a/name-as/src/nma.rs
+++ b/name-as/src/nma.rs
@@ -574,7 +574,9 @@ pub fn assemble(program_arguments: &Args) -> Result<(), String> {
                     return Err("Failed to match instruction".to_string());
                 }
             }
-            MipsCST::Label(label) => {
+            // For the record, label is not yet used. I've prefixed it with an underscore to denote this for now,
+            // but that can and should change.
+            MipsCST::Label(_label) => {
                 continue;
             }
             _ => continue,

--- a/name-ext/src/extension.ts
+++ b/name-ext/src/extension.ts
@@ -72,14 +72,17 @@ export function activate(context: vscode.ExtensionContext) {
 				terminal = terminal ? terminal : vscode.window.createTerminal(terminalOptions);
 				terminal.show();
 
+				// TODO: Create a bin/ dir which contains the compiled binaries for each OS
 				// Build and run assembler
 				terminal.sendText(`cd ${nameASPath}`);
 				terminal.sendText(`cargo build --release`);
-				terminal.sendText(`cargo run ${nameDefaultCfgPath} ${currentlyOpenTabFilePath} ${currentlyOpenDirectory}\\${currentlyOpenTabFileName}.o`);
+				terminal.sendText(`cargo run ${nameDefaultCfgPath} ${currentlyOpenTabFilePath} ${currentlyOpenDirectory}/${currentlyOpenTabFileName}.o`);
 				
 				// Build and run emulator
 				terminal.sendText(`cd ${nameEMUPath}`);
 				terminal.sendText('cargo build --release');
+				terminal.sendText(`cargo run 63321 ${currentlyOpenTabFilePath} ${currentlyOpenDirectory}/${currentlyOpenTabFileName}.o ${currentlyOpenDirectory}/${currentlyOpenTabFileName}.o.li`);
+
 			}
 
 			// Kill child process if it's still alive

--- a/name-ext/src/extension.ts
+++ b/name-ext/src/extension.ts
@@ -11,8 +11,9 @@ const termName = "NAME Emulator";
 
 const runMode: 'external' | 'server' | 'namedPipeServer' | 'inline' = 'server';
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
+// TODO: Allow this code to run on Windows, Linux, and macOS.
+// The current issue is that the paths are made with linux in mind.
+// There exist libraries which would resolve this.
 export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand("extension.vsname.startEmu", () => {
@@ -30,7 +31,6 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 
 			const nameASPath = path.join(namePath, 'name-as');
-			const nameTMPPath = path.join(namePath, 'tmp');
 			const nameDefaultCfgPath = path.join(nameASPath, 'configs/default.toml');
 			const nameEMUPath = path.join(namePath, 'name-emu');
 			const nameEXTPath = path.join(namePath, 'name-ext');
@@ -71,11 +71,6 @@ export function activate(context: vscode.ExtensionContext) {
 				var terminal = vscode.window.terminals.find(terminal => terminal.name === termName);
 				terminal = terminal ? terminal : vscode.window.createTerminal(terminalOptions);
 				terminal.show();
-				//terminal.sendText('clear');
-
-				// Make the temp directory
-				terminal.sendText(`cd ${namePath}`);
-				terminal.sendText(`mkdir tmp`);
 
 				// Build and run assembler
 				terminal.sendText(`cd ${nameASPath}`);
@@ -85,8 +80,6 @@ export function activate(context: vscode.ExtensionContext) {
 				// Build and run emulator
 				terminal.sendText(`cd ${nameEMUPath}`);
 				terminal.sendText('cargo build --release');
-				// Exit when emulator quits
-				// terminal.sendText('exit');
 			}
 
 			// Kill child process if it's still alive


### PR DESCRIPTION
This branch did not need to exist to begin with. It was filed under "documentation", meaning there was no reason to create a separate branch for changes as they could have simply been fixed in a commit. 

In this PR is also a choice which was hard for me to make, but I chose to remove .artifacts from the name-as directory. I didn't think it was smart to keep it, but I do plan to add dedicated test materials later on down the line. While I understand the original rationale, it no longer makes sense.