### PR TITLE
Debugger panel launches + test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ tmp/*
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
-*.asm
 *.out
 *.o
 *.li

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ In its current state, when building from source, NAME will not function unless `
 
 ## Test Files
 
-Some test files have been included. You can find them in [test files](test_files.md).
+Some test files have been included. You can find them in [test files](test_files/test_files.md).

--- a/name-as/src/main.rs
+++ b/name-as/src/main.rs
@@ -1,6 +1,5 @@
 extern crate pest;
 extern crate pest_derive;
-//use name_const::LineInfo;
 
 pub mod args;
 pub mod config;

--- a/name-as/src/nma.rs
+++ b/name-as/src/nma.rs
@@ -354,6 +354,7 @@ fn assemble_r(r_struct: R, r_args: Vec<&str>) -> Result<u32, &'static str> {
     Ok(result)
 }
 
+// Assembles an R-type instruction that takes no arguments (syscall)
 fn assemble_r_keyword(r_struct: R) -> Result<u32, &'static str> {
     let result: u32;
     println!("funct: {}", r_struct.funct);

--- a/name-emu/src/args.rs
+++ b/name-emu/src/args.rs
@@ -1,0 +1,71 @@
+use std::env;
+// This is the port on which vscode's DAP communicates.
+const VSCODE_DAP_PORT: i32 = 63321;
+
+#[derive(Debug)]
+pub struct Args{
+    pub port: i32,
+    pub source_file: String,
+    pub object_file: String,
+    pub lineinfo_file: String,
+    pub debug: bool,
+}
+
+fn help(){
+    println!("USAGE: name-emu [OPTIONS] SOURCE OBJECT LINEINFO\n");
+    println!("Required:");
+    println!("  SOURCE        The source code file");
+    println!("  OBJECT        The corresponding object file");
+    println!("  LINEINFO      The corresponding lineinfo file");
+    println!("Optional:");
+    println!("  --debug ");
+    println!("  -d            Enable debugging (for vscode DAP)");
+}
+
+pub fn parse_args() -> Result<Args, &'static str> {
+    let mut args: Args = Args {
+        port: VSCODE_DAP_PORT,
+        source_file: String::new(),
+        object_file: String::new(),
+        lineinfo_file: String::new(),
+        debug: false,
+    };
+    let args_strings: Vec<String> = env::args().collect();
+
+    if args_strings.len() < 4 {
+        help();
+        return Err("Improper usage.");
+    }
+
+    let mut arg_index = 1;
+    for arg in args_strings.iter().skip(1) {
+        let mut parsed_option = true;
+        match arg.as_str() {
+            "-d" | "--debug" => args.debug = true,
+            _ => parsed_option = false,
+        };
+
+        if parsed_option {
+            continue;
+        }
+
+        match arg_index {
+            1 => args.source_file = arg.to_string(),
+            2 => args.object_file = arg.to_string(),
+            3 => args.lineinfo_file = arg.to_string(),
+            _ => return Err("Argument out of bounds"),
+        }
+
+        arg_index += 1;
+    }
+
+    if args.source_file == String::new() {
+        return Err("Expected a source file but none provided");
+    } else if args.object_file == String::new() {
+        return Err("Expected an assembled object file but none provided");
+    } else if args.lineinfo_file == String::new() {
+        return Err("Expected a lineinfo file but none provided");
+    }
+
+    Ok(args)
+}

--- a/name-emu/src/exception.rs
+++ b/name-emu/src/exception.rs
@@ -19,10 +19,7 @@ pub enum ExecutionErrors {
     // Can also refer to underflow
     IntegerOverflow { rt: usize, rs: usize, value1: u32, value2: u32 },
 
-    /*
-    // Lol unused
-    SyscallInvalidArugment,
-    */
+    ExecutionTerminatedUnexpected,
 
     SyscallInvalidSyscallNumber,
 
@@ -102,6 +99,14 @@ pub fn exception_pretty_print(reason: Result<(), ExecutionErrors>) -> ExceptionI
                 message: Some( format!("rs: {}, value: {:x}\nrt: {}, value: {:x}", REGISTER_NAMES[rs], value1, REGISTER_NAMES[rt], value2)
             ), 
             type_name: None, full_type_name: None, evaluate_name: None, stack_trace: None, inner_exception: None })
+        },
+
+        ExecutionErrors::ExecutionTerminatedUnexpected { .. } =>
+        ExceptionInfoResponse {
+            exception_id: "Execution Terminated Unexpectedly".into(),
+            description: Some("Execution fell off bottom. It is likely syscall 10 (SysExit) was never issued.".into()),
+            break_mode: ExceptionBreakMode::Never,
+            details: None
         },
             
         _ => unimplemented!("adf"),

--- a/name-emu/src/mips.rs
+++ b/name-emu/src/mips.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::Write;
 
 
-use crate::{exception::{ExecutionErrors, ExecutionEvents}, syscall::syscall};
+use crate::{exception::{ExecutionErrors, /*ExecutionEvents*/}, syscall::syscall}; // Execution Events not yet implemented
 
 const MIPS_INSTRUCTION_LENGTH: usize = 4;
 const DOT_TEXT_START_ADDRESS: u32 = 0x400000; // Keeping consistency with name-as
@@ -520,7 +520,7 @@ impl Mips {
         self.pc += MIPS_INSTRUCTION_LENGTH;
 
         if self.pc == self.stop_address {
-            return Err(ExecutionErrors::Event { event: ExecutionEvents::ProgramComplete });
+            return Err(ExecutionErrors::ExecutionTerminatedUnexpected);
         }
 
         let instruction = self.decode(opcode);

--- a/name-emu/src/mips.rs
+++ b/name-emu/src/mips.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::Write;
 
 
-use crate::{exception::{ExecutionErrors, /*ExecutionEvents*/}, syscall::syscall}; // Execution Events not yet implemented
+use crate::{exception::{ExecutionErrors, /*ExecutionEvents*/}, syscall::syscall}; // TODO: Implement execution events
 
 const MIPS_INSTRUCTION_LENGTH: usize = 4;
 const DOT_TEXT_START_ADDRESS: u32 = 0x400000; // Keeping consistency with name-as
@@ -99,7 +99,7 @@ impl Default for Mips {
     fn default() -> Self {
         Self {
             regs: [0; 32],
-            // This is also dead code for right now
+            // This is dead code for right now
             /*
             floats: [0f32; 32],
             mult_hi: 0,
@@ -138,7 +138,6 @@ struct Jtype {
     dest: u32
 }
 
-// struct Jtype
 // struct Ftype
 
 #[derive(Debug)]
@@ -155,19 +154,19 @@ impl Mips {
 
         match ins.funct {
             // Shift-left logical
-            0x0 => {
+            0x00 => {
                 self.regs[ins.rd] = self.regs[ins.rt] << ins.shamt;
             }
             // Shift-right logical
-            0x2 => {
+            0x02 => {
                 self.regs[ins.rd] = self.regs[ins.rt] >> ins.shamt;
             }
             // Jump Register
-            0x8 => {
+            0x08 => {
                 self.pc = self.regs[ins.rs] as usize;
             }
             // System Call
-            0xC => {
+            0x0C => {
                 // Grab 20-bit code field
                 let code = (opcode >> 6) & 0xFFFFF;
                 syscall(self, code)?;
@@ -238,9 +237,21 @@ impl Mips {
         let memory_address = self.regs[ins.rs].wrapping_add(ins.imm as u32);
 
         match ins.opcode {
+            // Branch if Equal
+            0x04 => {
+                if self.regs[ins.rt] == self.regs[ins.rs] {
+                    self.configure_branch(ins);
+                }
+            }
+            // Branch if Not Equal
+            0x05 => {
+                if self.regs[ins.rt] != self.regs[ins.rs] {
+                    self.configure_branch(ins);
+                }
+            }
             // Branch on Less than Zero
             // MIPS manual says: If the contents of GPR rs are less than zero (sign bit is 1)
-            0x6 => {
+            0x06 => {
                 if self.regs[ins.rs] as i32 <= 0 {
                     self.configure_branch(ins);
                 }
@@ -248,13 +259,13 @@ impl Mips {
             // Branch on Greater than Zero
             // MIPS manual says: If the contents of GPR rs 
             // are greater than zero (sign bit is 0 but value not zero)
-            0x7 => {
+            0x07 => {
                 if self.regs[ins.rs] > 0 {
                     self.configure_branch(ins);
                 }
             }
             // Add Immediate
-            0x8 => {
+            0x08 => {
                 let result = self.regs[ins.rs].checked_add_signed(ins.imm as i16 as i32);
                 match result {
                     Some(value) => {self.regs[ins.rt] = value;}
@@ -269,29 +280,39 @@ impl Mips {
                 }
             }
             // Add Immediate Unsigned
-            0x9 => {
+            0x09 => {
                 self.regs[ins.rt] = self.regs[ins.rs].wrapping_add(ins.imm as u32);
             }
             // Set on Less Than Immediate (signed)
             // If rs is less than sign-extended 16 bit immediate using signed comparison, then set rt to 1
             // Casting on imm is to sign extend. See load byte casts
-            0xA => { 
+            0x0A => { 
                 self.regs[ins.rt] = if (self.regs[ins.rs] as i32) < (ins.imm as i16 as i32) { 1 } else { 0 };
             }
             // Set on Less Than Immediate (unsigned)
             // If rs is less than sign-extended 16-bit immediate using unsigned comparison, then set rt to 1
             // casting is to sign extend again
-            0xB => { 
+            0x0B => { 
                 self.regs[ins.rt] = if self.regs[ins.rs] < (ins.imm as i16 as i32 as u32) { 1 } else { 0 };
             }
             // Or Immediate
-            0xD => {
+            0x0D => {
                 // Rust zero-extends unsigned values when up-casting
                 self.regs[ins.rt] = self.regs[ins.rs] | ins.imm as u32;
             }
             // Load Upper Immediate
-            0xF => {
+            0x0F => {
                 self.regs[ins.rt] = (ins.imm as u32) << 16;
+            }
+            // Load byte (signed)
+            // Note that I force a sign extension through a convuluted series of casts
+            // u8 -> i8 (same bits) -> i32 (more bits, sign extension) -> u32 (same bits)
+            0x20 => {
+                self.regs[ins.rt] = self.read_b(memory_address)? as i8 as i32 as u32;
+            }
+            // Load halfword (signed), same deal
+            0x21 => {
+                self.regs[ins.rt] = self.read_h(memory_address)? as i16 as i32 as u32;
             }
             // Load word (0x23) and Load Linked (0x30).
             // A word on Load Linked-- This is an instruction for atomic accesses
@@ -310,16 +331,6 @@ impl Mips {
             0x25 => {
                 self.regs[ins.rt] = self.read_h(memory_address)? as u32;
             }
-            // Load byte (signed)
-            // Note that I force a sign extension through a convuluted series of casts
-            // u8 -> i8 (same bits) -> i32 (more bits, sign extension) -> u32 (same bits)
-            0x20 => {
-                self.regs[ins.rt] = self.read_b(memory_address)? as i8 as i32 as u32;
-            }
-            // Load halfword (signed), same deal
-            0x21 => {
-                self.regs[ins.rt] = self.read_h(memory_address)? as i16 as i32 as u32;
-            }
             // Store byte
             0x28 => {
                 self.write_b(memory_address, self.regs[ins.rt] as u8)?;
@@ -333,18 +344,6 @@ impl Mips {
             // op for the same reason.
             0x2b | 0x38 => {
                 self.write_w(memory_address, self.regs[ins.rt])?;
-            }
-            // Branch if Equal
-            0x4 => {
-                if self.regs[ins.rt] == self.regs[ins.rs] {
-                    self.configure_branch(ins);
-                }
-            }
-            // Branch if Not Equal
-            0x5 => {
-                if self.regs[ins.rt] != self.regs[ins.rs] {
-                    self.configure_branch(ins);
-                }
             }
             
 

--- a/name-emu/src/syscall.rs
+++ b/name-emu/src/syscall.rs
@@ -5,18 +5,62 @@ use crate::mips::Mips;
 use crate::exception::{ExecutionErrors, ExecutionEvents};
 // use std::io::Stdin; // Lmao unused
 
-// For now, code is prefaced with '_' as it is unused
-pub(crate) fn syscall(mips: &mut Mips, _code: u32) -> Result<(), ExecutionErrors> {
-    match mips.regs[2] {
+const LAST_AVAILABLE_SYSCALL: u32 = 11;
 
-        // Print integer. Writes the value in $a0 to the screen
-        1 => {
-            print!("{}", mips.regs[4]);
-            Ok(())
-        }
-        // Print string. Writes null-terminated string pointed to by $a0 to the screen
-        4 => {
-            let mut str_vec = vec![];
+// If you're curious what this is, take a look right below.
+type SyscallFn = fn(&mut Mips) -> Result<(), ExecutionErrors>;
+
+// This is the syscall lookup table. It consists of a set of function pointers which are used to actually execute the syscalls in question.
+// Each function has the type SyscallFn, declared above.
+// We use LAST_AVAILABLE_SYSCALL + 1 since arrays are zero-indexed.
+const SYSCALL_LOOKUP_TABLE: [SyscallFn; (LAST_AVAILABLE_SYSCALL as usize) + 1] = [
+    nonimpl, // 0
+    sys_print_int, // 1
+    nonimpl, // 2
+    nonimpl, // 3
+    sys_print_string, // 4
+    nonimpl, // 5
+    nonimpl, // 6
+    nonimpl, // 7
+    nonimpl, // 8
+    nonimpl, // 9
+    sys_exit, // 10
+    sys_print_char, // 11
+];
+
+// For now, code is prefaced with '_' as it is unused
+// This is insanely simple. Just perform a very simple lookup that calls the right function pointer.
+pub(crate) fn syscall(mips: &mut Mips, _code: u32) -> Result<(), ExecutionErrors> {
+    if mips.regs[2] < 1 {
+        return Err(ExecutionErrors::SyscallInvalidSyscallNumber);
+    } else if mips.regs[2] > LAST_AVAILABLE_SYSCALL {
+        nonimpl(mips)?;
+        panic!();
+    } else {
+        SYSCALL_LOOKUP_TABLE[mips.regs[2] as usize](mips)?;
+        return Ok(());
+    }
+}
+
+// Function implementations for each of the syscalls
+
+// Applies to syscall 0 (since arrays are zero-indexed) and anything not yet implemented.
+fn nonimpl(_mips: &mut Mips) -> Result<(), ExecutionErrors>{
+    println!("The syscall you attempted to use has not yet been implemented.");
+    return Err(ExecutionErrors::SyscallInvalidSyscallNumber);
+}
+
+// Syscall 1 - Print the value in $a0 ($4) to the screen.
+fn sys_print_int(mips: &mut Mips) -> Result<(), ExecutionErrors>{
+    print!("{}", mips.regs[4]);
+    return Ok(())
+}
+
+// Syscall 2
+// Syscall 3
+// Syscall 4 - Print string; writes the null-terminated value pointed to by $a0 ($4) to screen.
+fn sys_print_string(mips: &mut Mips) -> Result<(), ExecutionErrors>{
+    let mut str_vec = vec![];
             let mut i = 0;
             loop {
                 let read_char = mips.read_b(mips.regs[4] + i)?;
@@ -28,18 +72,21 @@ pub(crate) fn syscall(mips: &mut Mips, _code: u32) -> Result<(), ExecutionErrors
             };
             print!("{}", str_vec.iter().collect::<String>());
             Ok(())
-        }
-        // Exit. Immediately raise a ProgramComplete event
-        10 => {
-            Err(ExecutionErrors::Event { event: ExecutionEvents::ProgramComplete })
-        }
-        // Print char. Writes the value in $a0 as a char to the screen
-        11 => {
-            if let Some(c) = std::char::from_u32(mips.regs[4]) {
-                print!("{}", c);
-            }
-            Ok(())
-        }
-        _ => Err(ExecutionErrors::SyscallInvalidSyscallNumber)
+}
+// Syscall 4
+// Syscall 5
+// Syscall 6
+// Syscall 7
+// Syscall 8
+// Syscall 9
+// Syscall 10 - System exit (raises a program complete execution event)
+fn sys_exit(_mips: &mut Mips) -> Result<(), ExecutionErrors>{
+    return Err(ExecutionErrors::Event{ event: ExecutionEvents::ProgramComplete });
+}
+// Syscall 11 - Print char: writes the char in $a0 ($4) to the screen.
+fn sys_print_char(mips: &mut Mips) -> Result<(), ExecutionErrors>{
+    if let Some(c) = std::char::from_u32(mips.regs[4]) {
+        print!("{}", c);
     }
+    Ok(())
 }

--- a/name-emu/src/syscall.rs
+++ b/name-emu/src/syscall.rs
@@ -5,7 +5,7 @@ use crate::mips::Mips;
 use crate::exception::{ExecutionErrors, ExecutionEvents};
 // use std::io::Stdin; // Lmao unused
 
-// TODO: Refactor to use "code" instead of register 2 ($v0). For now, code is prefaced with '_'.
+// For now, code is prefaced with '_' as it is unused
 pub(crate) fn syscall(mips: &mut Mips, _code: u32) -> Result<(), ExecutionErrors> {
     match mips.regs[2] {
 
@@ -29,7 +29,7 @@ pub(crate) fn syscall(mips: &mut Mips, _code: u32) -> Result<(), ExecutionErrors
             print!("{}", str_vec.iter().collect::<String>());
             Ok(())
         }
-        // Exit. Immediately raise a ProgramComplete error
+        // Exit. Immediately raise a ProgramComplete event
         10 => {
             Err(ExecutionErrors::Event { event: ExecutionEvents::ProgramComplete })
         }

--- a/name-ext/src/activateNameDebug.ts
+++ b/name-ext/src/activateNameDebug.ts
@@ -157,6 +157,6 @@ class NameConfigurationProvider implements vscode.DebugConfigurationProvider {
 class ExecutableDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {
 
 	createDebugAdapterDescriptor(_session: vscode.DebugSession): ProviderResult<vscode.DebugAdapterDescriptor> {
-		return new vscode.DebugAdapterExecutable('/home/qwe/Documents/CS4485/name/name-emu/target/release/name');
+		return new vscode.DebugAdapterExecutable('/home/teqqy/Projects/name/name-emu/target/release/name');
 	}
 }

--- a/test_files/hello_world/hello_world.asm
+++ b/test_files/hello_world/hello_world.asm
@@ -1,0 +1,15 @@
+# Hello, world!
+    .eqv    SysPrintString, 4
+    .eqv    SysExit, 10
+    
+    .data
+
+OurBelovedString:
+    .asciiz     "Hello, World!"
+
+    .text
+    la  $a0, OurBelovedString
+    li  $v0, SysPrintString
+    syscall
+    li  $v0, SysExit
+    syscall

--- a/test_files/instruction_demonstration/.vscode/launch.json
+++ b/test_files/instruction_demonstration/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "vsname",
+            "request": "launch",
+            "name": "Ask for file name",
+            "program": "${workspaceFolder}/${command:AskForProgramName}",
+            "stopOnEntry": true
+        }
+    ]
+}

--- a/test_files/instruction_demonstration/mips_test.asm
+++ b/test_files/instruction_demonstration/mips_test.asm
@@ -1,0 +1,24 @@
+main:   
+    add          $t0,$t2,$t3
+    sub          $t4, $t5, $t6
+    sll          $s0, $s0, 5
+    srl          $s5, $s7, 10
+    xor          $t7, $t8, $t9
+    lui          $t0, 50
+    ori          $t0, $t1, 50
+    ori          $t0, $t0, 0x50
+    ori          $t0, $t0, 050
+    ori          $t0, $t0, 0b1010
+    lb           $t0, 0x50($t1)
+    lb           $t0, 50($t1)
+    lb           $t0, ($t1)
+    beq          $s0, $s0, test
+test:
+    j           skip
+skip:
+    jal         done
+done:
+    add         $t0, $zero, $zero
+exit:
+    lui         $v0, 10
+    syscall

--- a/test_files/test_files.md
+++ b/test_files/test_files.md
@@ -5,8 +5,13 @@ Included in this directory are a couple of test files to get you started with NA
 ## Included tests
 
 - ~~Hello, World!~~ *(Not yet included)*
+    - Just a simple test of very basic instructions.
 - ~~Fibonacci sequence (fib.asm)~~ *(Not yet included)*
+    - A more sophisticated test.
+- Palindrome checker (palindromes.asm)
+    - A test for assembly across multiple files.
 - Instruction demonstration (mips_test.asm)
+    - A demo of various instructions present in NAME's simulation.
 
 ## Getting started
 


### PR DESCRIPTION
This set of improvements includes a complete rework of the syscall implementation. A large match statement was replaced with a lookup table for the syscalls (since they're just numbers). Dead code was largely removed or refactored, and in general the outer functionality has remained the same whilst improvements were made under the hood (for ease of further development).

Additionally, test files were added to demonstrate the full functionality of NAME. README.md was updated to reflect these, and an explanatory test_files.md was added to the test_files directory to explain the rationale and provide essentially a tutorial on using NAME.