### PR TITLE
MacOS Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ DEBUG_ADAPTER_DIR = name-debug-adapter
 BIN_DIR = $(EXT_DIR)/bin
 
 TARGET_WIN = x86_64-pc-windows-gnu
+TARGET_MAC_INTEL = x86_64-apple-darwin
+TARGET_MAC_ARM64 = aarch64-apple-darwin
 TARGET_LINUX = x86_64-unknown-linux-gnu
 
 all: build-linux build-windows extension-compile
@@ -36,6 +38,28 @@ build-windows:
 	cd $(DEBUG_ADAPTER_DIR) && cargo build --release --target $(TARGET_WIN)
 	mv -n target/$(TARGET_WIN)/release/name-debug-adapter.exe $(BIN_DIR)/
 
+build-mac-x86_64:
+	mkdir -p $(BIN_DIR)
+	cd $(AS_DIR) && cargo build --release --target $(TARGET_MAC_INTEL)
+	mv -n target/$(TARGET_MAC_INTEL)/release/name-as_x86_64.app $(BIN_DIR)/
+	cd $(LD_DIR) && cargo build --release --target $(TARGET_MAC_INTEL)
+	mv -n target/$(TARGET_MAC_INTEL)/release/name-ld_x86_64.app $(BIN_DIR)/
+	cd $(EMU_DIR) && cargo build --release --target $(TARGET_MAC_INTEL)
+	mv -n target/$(TARGET_MAC_INTEL)/release/name-emu_x86_64.app $(BIN_DIR)/
+	cd $(DEBUG_ADAPTER_DIR) && cargo build --release --target $(TARGET_MAC_INTEL)
+	mv -n target/$(TARGET_MAC_INTEL)/release/name-debug-adapter_x86_64.app $(BIN_DIR)/
+
+build-mac-arm64:
+	mkdir -p $(BIN_DIR)
+	cd $(AS_DIR) && cargo build --release --target $(TARGET_MAC_ARM64)
+	mv -n target/$(TARGET_MAC_ARM64)/release/name-as_arm64.app $(BIN_DIR)/
+	cd $(LD_DIR) && cargo build --release --target $(TARGET_MAC_ARM64)
+	mv -n target/$(TARGET_MAC_ARM64)/release/name-ld_arm64.app $(BIN_DIR)/
+	cd $(EMU_DIR) && cargo build --release --target $(TARGET_MAC_ARM64)
+	mv -n target/$(TARGET_MAC_ARM64)/release/name-emu_arm64.app $(BIN_DIR)/
+	cd $(DEBUG_ADAPTER_DIR) && cargo build --release --target $(TARGET_MAC_ARM64)
+	mv -n target/$(TARGET_MAC_ARM64)/release/name-debug-adapter_arm64.app $(BIN_DIR)/
+
 extension-compile:
 	cd $(EXT_DIR) && npm run compile
 
@@ -47,4 +71,6 @@ setup:
 	read -n 1 -s -r -p "Press any key to continue"
 	rustup target add $(TARGET_WIN)
 	rustup target add $(TARGET_LINUX)
+	rustup target add $(TARGET_MAC_INTEL)
+	rustup target add $(TARGET_MAC_ARM64)
 	@echo "Please install nodejs, npm, and tsc to compile the extension."

--- a/name-as/src/args.rs
+++ b/name-as/src/args.rs
@@ -8,5 +8,3 @@ pub struct Cli {
     #[arg(short, long)]
     pub verbose: bool,
 }
-
-// Test change 

--- a/name-as/src/args.rs
+++ b/name-as/src/args.rs
@@ -8,3 +8,5 @@ pub struct Cli {
     #[arg(short, long)]
     pub verbose: bool,
 }
+
+// Test change 

--- a/name-ext/package.json
+++ b/name-ext/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "name-ext",
   "displayName": "VSName",
@@ -122,16 +121,16 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.96.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "20.x",
+    "@types/node": "^20.17.46",
+    "@types/vscode": "^1.96.0",
     "@typescript-eslint/eslint-plugin": "^8.22.0",
     "@typescript-eslint/parser": "^8.22.0",
-    "eslint": "^9.19.0",
-    "esbuild": "^0.24.2",
-    "npm-run-all": "^4.1.5",
-    "typescript": "^5.7.3",
     "@vscode/test-cli": "^0.0.10",
-    "@vscode/test-electron": "^2.4.1"
+    "@vscode/test-electron": "^2.4.1",
+    "esbuild": "^0.25.4",
+    "eslint": "^9.19.0",
+    "npm-run-all": "^4.1.5",
+    "typescript": "^5.7.3"
   }
 }

--- a/name-ext/src/helpers/getbin.ts
+++ b/name-ext/src/helpers/getbin.ts
@@ -1,5 +1,30 @@
 // Generalization of os-specific binary grabbing
-export function getBinName(nomenclature: string) : string {
-    const isWindows = process.platform === 'win32';
-    return isWindows ? `${nomenclature}.exe` : nomenclature;
+// Creates a name for the binary file depending on platform and architecture.
+export function getBinName(nomenclature: string): string {
+    let binName: string;
+
+    switch (process.platform) {
+        case 'win32':
+            binName = `${nomenclature}.exe`;
+            break;
+        case 'darwin':
+            // Suffix the executable depending on which 
+            // type of architecture the Mac uses
+            if (process.arch === 'x64') {
+                binName = `${nomenclature}_x86_64`;
+            } else {
+                binName = `${nomenclature}_arm64`;
+            }
+            
+            // Add an .app extension for all Mac versions
+            binName = binName + '.app';
+            break;
+        case 'linux':
+            binName = `${nomenclature}.bin`;
+            break;
+        default:
+            throw Error('Unknown platform');
+    }
+
+    return binName;
 }


### PR DESCRIPTION
Added functionality for compiling for Mac (Intel and ARM64) and creating binary names for Mac. 

Files edited:
- getbin.ts (name/name-ext/src/helpers/getbin.ts)
- Makefile (name/Makefile)